### PR TITLE
Task2 create license metric

### DIFF
--- a/src/ModelCatalogue.py
+++ b/src/ModelCatalogue.py
@@ -27,9 +27,9 @@ class ModelCatalogue:
             Dataset URL = '{}',
             Code URL = '{}'
             """,
-            model.modelURL,
-            model.datasetURL,
-            model.codeURL
+            model.modelLink,
+            model.datasetLink,
+            model.codeLink
         )
 
     def evaluateModels(self):

--- a/src/ModelCatalogue.py
+++ b/src/ModelCatalogue.py
@@ -3,6 +3,7 @@ import json
 from loguru import logger
 
 from src.Metric import Metric
+from src.metrics.LicenseMetric import LicenseMetric
 from src.Model import Model
 
 
@@ -13,7 +14,9 @@ class ModelCatalogue:
 
     def __init__(self):
         self.models: list[Model] = []
-        self.metrics: list[Metric] = []
+        self.metrics: list[Metric] = [
+            LicenseMetric()
+        ]
 
     def addModel(self, model: Model):
         self.models.append(model)

--- a/src/commands/catalogue_runner.py
+++ b/src/commands/catalogue_runner.py
@@ -67,5 +67,6 @@ def run_catalogue(file_path: str) -> int:
     for url_bundle in url_bundles:
         catalogue.addModel(Model(url_bundle))
 
+    catalogue.evaluateModels()
     print(catalogue.generateReport())
     return 0

--- a/src/metrics/LicenseMetric.py
+++ b/src/metrics/LicenseMetric.py
@@ -1,12 +1,85 @@
+import requests
+
 from Metric import Metric
 
 
 class LicenseMetric(Metric):
+    LICENSE_COMPATIBILITY = {
+        "MIT": 1.0,
+        "BSD-2-Clause": 1.0,
+        "BSD-3-Clause": 1.0,
+        "LGPL-2.1": 1.0,
+        "LGPL-2.1-or-later": 1.0,
+        "GPL-2.0-or-later": 1.0,
+
+        "GPL-2.0": 0.5,
+        "MPL-2.0": 0.5,
+        "Unlicense": 0.5,
+
+        "Apache-2.0": 0.0,
+        "GPL-3.0": 0.0,
+        "LGPL-3.0": 0.0,
+        "AGPL-3.0": 0.0,
+        "Proprietary": 0.0
+    }
+
     def evaluate(
         self,
         modelLink: str = "",
         datasetLink: str = "",
         codeLink: str = ""
     ) -> float:
-        # Implement license evaluation logic here
-        return 0.0
+        """
+        Evaluate the license compatibility of the provided model, dataset, or code link
+        against the LGPL-2.1 license used by this project.
+
+        This method currently focuses on the `codeLink`, checking its license (via
+        GitHub API if applicable), and comparing it against a predefined list of 
+        compatible and incompatible licenses with respect to LGPL-2.1.
+
+        Returns a float score in the range [0.0, 1.0]:
+            - 1.0: License is known and fully compatible with LGPL-2.1
+            - 0.5: License is unknown, ambiguous, or cannot be determined
+            - 0.0: License is known and incompatible with LGPL-2.1
+
+        Parameters:
+            modelLink (str): URL to the AI/ML model (not used in current version)
+            datasetLink (str): Optional URL to the dataset (not used in current version)
+            codeLink (str): URL to the source code repository (preferably GitHub)
+
+        Returns:
+            float: A compatibility score between 0.0 and 1.0.
+        """
+        if not codeLink:
+            return 0.5  # No code provided: unknown
+
+        license_id = self._get_spdx_license_from_github(codeLink)
+        return self.LICENSE_COMPATIBILITY.get(license_id, 0.5)  # Default: ambiguous
+
+    def _get_spdx_license_from_github(self, repo_url: str) -> str:
+        """
+        Extracts the SPDX license ID from a GitHub repo using the GitHub API.
+        Assumes repo_url is in the format https://github.com/{owner}/{repo}
+        """
+        try:
+            if "github.com" not in repo_url:
+                return ""
+
+            parts = repo_url.rstrip("/").split("/")
+            if len(parts) < 5:
+                return ""
+
+            owner, repo = parts[3], parts[4]
+            api_url = f"https://api.github.com/repos/{owner}/{repo}/license"
+            headers = {
+                "Accept": "application/vnd.github.v3+json"
+            }
+
+            response = requests.get(api_url, headers=headers)
+            if response.status_code == 200:
+                data = response.json()
+                return data.get("license", {}).get("spdx_id", "")
+            else:
+                return ""
+        except Exception:
+            return ""

--- a/src/metrics/LicenseMetric.py
+++ b/src/metrics/LicenseMetric.py
@@ -1,6 +1,7 @@
 import requests
+from loguru import logger
 
-from Metric import Metric
+from src.Metric import Metric
 
 
 class LicenseMetric(Metric):
@@ -34,7 +35,7 @@ class LicenseMetric(Metric):
         against the LGPL-2.1 license used by this project.
 
         This method currently focuses on the `codeLink`, checking its license (via
-        GitHub API if applicable), and comparing it against a predefined list of 
+        GitHub API if applicable), and comparing it against a predefined list of
         compatible and incompatible licenses with respect to LGPL-2.1.
 
         Returns a float score in the range [0.0, 1.0]:
@@ -50,11 +51,15 @@ class LicenseMetric(Metric):
         Returns:
             float: A compatibility score between 0.0 and 1.0.
         """
+        logger.info("Evaluating LicenseMetric...")
         if not codeLink:
+            logger.info("LicenseMetric: No Code URL -> 0.0")
             return 0.5  # No code provided: unknown
 
         license_id = self._get_spdx_license_from_github(codeLink)
-        return self.LICENSE_COMPATIBILITY.get(license_id, 0.5)  # Default: ambiguous
+        license_score = self.LICENSE_COMPATIBILITY.get(license_id, 0.5)
+        logger.info("LicenseMetric: {} -> {}", license_id, license_score)
+        return license_score
 
     def _get_spdx_license_from_github(self, repo_url: str) -> str:
         """

--- a/tests/test_license_metric.py
+++ b/tests/test_license_metric.py
@@ -1,0 +1,61 @@
+import pytest
+from unittest.mock import patch
+
+from src.metrics.LicenseMetric import LicenseMetric
+
+
+@pytest.fixture
+def metric():
+    return LicenseMetric()
+
+
+@patch("src.metrics.LicenseMetric.requests.get")
+def test_compatible_license(mock_get, metric):
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {
+        "license": {"spdx_id": "MIT"}
+    }
+
+    score = metric.evaluate(codeLink="https://github.com/someuser/somerepo")
+    assert score == 1.0
+
+
+@patch("src.metrics.LicenseMetric.requests.get")
+def test_incompatible_license(mock_get, metric):
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {
+        "license": {"spdx_id": "GPL-3.0"}
+    }
+
+    score = metric.evaluate(codeLink="https://github.com/someuser/somerepo")
+    assert score == 0.0
+
+
+@patch("src.metrics.LicenseMetric.requests.get")
+def test_unknown_license(mock_get, metric):
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {
+        "license": {"spdx_id": "Some-Strange-License"}
+    }
+
+    score = metric.evaluate(codeLink="https://github.com/someuser/somerepo")
+    assert score == 0.5
+
+
+@patch("src.metrics.LicenseMetric.requests.get")
+def test_no_license_field(mock_get, metric):
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {}
+
+    score = metric.evaluate(codeLink="https://github.com/someuser/somerepo")
+    assert score == 0.5
+
+
+def test_non_github_url(metric):
+    score = metric.evaluate(codeLink="https://gitlab.com/some/repo")
+    assert score == 0.5
+
+
+def test_empty_code_link(metric):
+    score = metric.evaluate(codeLink="")
+    assert score == 0.5


### PR DESCRIPTION
- Added evaluation of license metric
  - Uses Github API to get SPDX license string
  - Incompatible -> 0
  - Unknown/Ambiguous -> 0.5
  - Compatible -> 1
 - Added logging to license metric
 - Added unit tests for license metric
 - Added call to evaluateMetrics in catalogue_runner
 - Added LicenseMetric to list of metrics in ModelCatalogue
 - Fixed minor bug with incorrect Model accessors in logging call in ModelCatalogue