### PR TITLE
Task9 evaluate net score

### DIFF
--- a/src/Interfaces.py
+++ b/src/Interfaces.py
@@ -1,0 +1,7 @@
+from typing import Protocol, Optional
+
+
+class ModelData(Protocol):
+    modelLink: str
+    codeLink: Optional[str]
+    datasetLink: Optional[str]

--- a/src/Metric.py
+++ b/src/Metric.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Union
 
-from src.Model import ModelData
+from src.Interfaces import ModelData
 
 
 class Metric(ABC):

--- a/src/Metric.py
+++ b/src/Metric.py
@@ -1,13 +1,10 @@
 from abc import ABC, abstractmethod
 from typing import Union
 
+from src.Model import ModelData
+
 
 class Metric(ABC):
     @abstractmethod
-    def evaluate(
-        self,
-        modelLink: str = "",
-        datasetLink: str = "",
-        codeLink: str = ""
-    ) -> Union[float, dict[str, float]]:
+    def evaluate(self, model: ModelData) -> Union[float, dict[str, float]]:
         pass

--- a/src/Model.py
+++ b/src/Model.py
@@ -1,11 +1,12 @@
 import time
-from typing import Union
+from typing import Union, Optional
 
+from src.Interfaces import ModelData
 from src.Metric import Metric
 from src.util.URLBundler import URLBundle
 
 
-class Model:
+class Model(ModelData):
 
     def __init__(
         self,
@@ -13,8 +14,8 @@ class Model:
     ):
         self.name = None
         self.modelLink: str = urls.model
-        self.codeLink: str | None = urls.code
-        self.datasetLink: str | None = urls.dataset
+        self.codeLink: Optional[str] = urls.code
+        self.datasetLink: Optional[str] = urls.dataset
 
         """
         evaluations maps metric names to their scores.
@@ -28,7 +29,7 @@ class Model:
 
         # Evaluate the given metric and record its score and evaluation time.
         start: float = time.time()
-        score: Union[float, dict[str, float]] = metric.evaluate()
+        score: Union[float, dict[str, float]] = metric.evaluate(self)
         end: float = time.time()
         elapsed: float = end - start
 

--- a/src/ModelCatalogue.py
+++ b/src/ModelCatalogue.py
@@ -37,6 +37,7 @@ class ModelCatalogue:
         for model in self.models:
             for metric in self.metrics:
                 model.evaluate(metric)
+            model.computeNetScore()
 
     def generateReport(self):
         # Generate a consolidated NDJSON report for all models.

--- a/src/metrics/AvailabilityMetric.py
+++ b/src/metrics/AvailabilityMetric.py
@@ -1,12 +1,8 @@
-from Metric import Metric
+from src.Interfaces import ModelData
+from src.Metric import Metric
 
 
 class AvailabilityMetric(Metric):
-    def evaluate(
-        self,
-        modelLink: str = "",
-        datasetLink: str = "",
-        codeLink: str = ""
-    ) -> float:
+    def evaluate(self, model: ModelData) -> float:
         # Implement availability evaluation logic here
         return 0.0

--- a/src/metrics/BusFactorMetric.py
+++ b/src/metrics/BusFactorMetric.py
@@ -1,12 +1,8 @@
-from Metric import Metric
+from src.Interfaces import ModelData
+from src.Metric import Metric
 
 
 class BusFactorMetric(Metric):
-    def evaluate(
-        self,
-        modelLink: str = "",
-        datasetLink: str = "",
-        codeLink: str = ""
-    ) -> float:
+    def evaluate(self, model: ModelData) -> float:
         # Implement bus factor evaluation logic here
         return 0.0

--- a/src/metrics/CodeQualityMetric.py
+++ b/src/metrics/CodeQualityMetric.py
@@ -1,12 +1,8 @@
-from Metric import Metric
+from src.Interfaces import ModelData
+from src.Metric import Metric
 
 
 class CodeQualityMetric(Metric):
-    def evaluate(
-        self,
-        modelLink: str = "",
-        datasetLink: str = "",
-        codeLink: str = ""
-    ) -> float:
+    def evaluate(self, model: ModelData) -> float:
         # Implement code quality evaluation logic here
         return 0.0

--- a/src/metrics/DatasetQualityMetric.py
+++ b/src/metrics/DatasetQualityMetric.py
@@ -1,12 +1,8 @@
-from Metric import Metric
+from src.Interfaces import ModelData
+from src.Metric import Metric
 
 
 class DatasetQualityMetric(Metric):
-    def evaluate(
-        self,
-        modelLink: str = "",
-        datasetLink: str = "",
-        codeLink: str = ""
-    ) -> float:
+    def evaluate(self, model: ModelData) -> float:
         # Implement dataset quality evaluation logic here
         return 0.0

--- a/src/metrics/LicenseMetric.py
+++ b/src/metrics/LicenseMetric.py
@@ -1,6 +1,7 @@
 import requests
 from loguru import logger
 
+from src.Interfaces import ModelData
 from src.Metric import Metric
 
 
@@ -24,12 +25,7 @@ class LicenseMetric(Metric):
         "Proprietary": 0.0
     }
 
-    def evaluate(
-        self,
-        modelLink: str = "",
-        datasetLink: str = "",
-        codeLink: str = ""
-    ) -> float:
+    def evaluate(self, model: ModelData) -> float:
         """
         Evaluate the license compatibility of the provided model, dataset, or code link
         against the LGPL-2.1 license used by this project.
@@ -52,11 +48,11 @@ class LicenseMetric(Metric):
             float: A compatibility score between 0.0 and 1.0.
         """
         logger.info("Evaluating LicenseMetric...")
-        if not codeLink:
+        if not model.codeLink:
             logger.info("LicenseMetric: No Code URL -> 0.0")
             return 0.5  # No code provided: unknown
 
-        license_id = self._get_spdx_license_from_github(codeLink)
+        license_id = self._get_spdx_license_from_github(model.codeLink)
         license_score = self.LICENSE_COMPATIBILITY.get(license_id, 0.5)
         logger.info("LicenseMetric: {} -> {}", license_id, license_score)
         return license_score

--- a/src/metrics/PerformanceClaimsMetric.py
+++ b/src/metrics/PerformanceClaimsMetric.py
@@ -1,12 +1,8 @@
-from Metric import Metric
+from src.Interfaces import ModelData
+from src.Metric import Metric
 
 
 class PerformanceClaimsMetric(Metric):
-    def evaluate(
-        self,
-        modelLink: str = "",
-        datasetLink: str = "",
-        codeLink: str = ""
-    ) -> float:
+    def evaluate(self, model: ModelData) -> float:
         # Implement performance claims evaluation logic here
         return 0.0

--- a/src/metrics/RampUpMetric.py
+++ b/src/metrics/RampUpMetric.py
@@ -1,12 +1,8 @@
-from Metric import Metric
+from src.Interfaces import ModelData
+from src.Metric import Metric
 
 
 class RampUpMetric(Metric):
-    def evaluate(
-        self,
-        modelLink: str = "",
-        datasetLink: str = "",
-        codeLink: str = ""
-    ) -> float:
+    def evaluate(self, model: ModelData) -> float:
         # Implement ramp-up evaluation logic here
         return 0.0

--- a/src/metrics/SizeMetric.py
+++ b/src/metrics/SizeMetric.py
@@ -1,12 +1,8 @@
-from Metric import Metric
+from src.Interfaces import ModelData
+from src.Metric import Metric
 
 
 class SizeMetric(Metric):
-    def evaluate(
-        self,
-        modelLink: str = "",
-        datasetLink: str = "",
-        codeLink: str = ""
-    ) -> dict[str, float]:
+    def evaluate(self, model: ModelData) -> dict[str, float]:
         # Implement size evaluation logic here
         return {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,40 @@
 """
-Pytest configuration and fixtures.
+Pytest configuration and reusable fixtures for model-hub-cli tests.
 """
+
+from dataclasses import dataclass
+from typing import Optional
+
 import pytest
 
 
+@dataclass
+class StubModelData:
+    """Stub implementation of the ModelData protocol for testing."""
+    modelLink: str
+    codeLink: Optional[str]
+    datasetLink: Optional[str]
+
+
 @pytest.fixture
-def sample_urls():
-    """Sample URLs for testing."""
+def base_model() -> StubModelData:
+    """
+    Fixture that returns a fully populated StubModelData instance.
+    Used as a baseline test model with valid HuggingFace and GitHub URLs.
+    """
+    return StubModelData(
+        modelLink="https://huggingface.co/microsoft/DialoGPT-medium",
+        codeLink="https://github.com/huggingface/transformers",
+        datasetLink="https://huggingface.co/datasets/squad"
+    )
+
+
+@pytest.fixture
+def sample_urls() -> list[str]:
+    """
+    Fixture that provides a sample list of model, dataset, and code URLs.
+    Used to simulate bundled input.
+    """
     return [
         "https://huggingface.co/datasets/squad",
         "https://github.com/huggingface/transformers",

--- a/tests/test_license_metric.py
+++ b/tests/test_license_metric.py
@@ -1,31 +1,13 @@
-import pytest
 from unittest.mock import patch
-from dataclasses import dataclass
-from typing import Optional
+
+import pytest
 
 from src.metrics.LicenseMetric import LicenseMetric
-
-
-@dataclass
-class StubModelData:
-    modelLink: str
-    codeLink: Optional[str]
-    datasetLink: Optional[str]
 
 
 @pytest.fixture
 def metric():
     return LicenseMetric()
-
-
-@pytest.fixture
-def base_model():
-    """Base stub model with common fields (overridden in tests)."""
-    return StubModelData(
-        modelLink="https://huggingface.co/some/model",
-        codeLink=None,
-        datasetLink="https://huggingface.co/datasets/some/dataset"
-    )
 
 
 @patch("src.metrics.LicenseMetric.requests.get")

--- a/tests/test_license_metric.py
+++ b/tests/test_license_metric.py
@@ -1,8 +1,9 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
 from src.metrics.LicenseMetric import LicenseMetric
+from tests.conftest import StubModelData
 
 
 @pytest.fixture
@@ -10,59 +11,114 @@ def metric():
     return LicenseMetric()
 
 
-@patch("src.metrics.LicenseMetric.requests.get")
-def test_compatible_license(mock_get, metric, base_model):
-    mock_get.return_value.status_code = 200
-    mock_get.return_value.json.return_value = {
-        "license": {"spdx_id": "MIT"}
-    }
+@pytest.fixture
+def hf_model():
+    return StubModelData(
+        modelLink="https://huggingface.co/facebook/bart-large",
+        codeLink="https://github.com/huggingface/transformers",
+        datasetLink="https://huggingface.co/datasets/squad"
+    )
 
-    base_model.codeLink = "https://github.com/someuser/somerepo"
-    score = metric.evaluate(base_model)
+
+@pytest.fixture
+def github_only_model():
+    return StubModelData(
+        modelLink="https://somewhere.else/model",
+        codeLink="https://github.com/someuser/somerepo",
+        datasetLink=None
+    )
+
+
+# HuggingFace License Tests
+@patch("src.metrics.LicenseMetric.requests.get")
+def test_license_from_huggingface(mock_get, metric, hf_model):
+    mock_get.return_value = Mock(status_code=200)
+    mock_get.return_value.json.return_value = {"cardData": {"license": "MIT"}}
+
+    score = metric.evaluate(hf_model)
     assert score == 1.0
 
 
 @patch("src.metrics.LicenseMetric.requests.get")
-def test_incompatible_license(mock_get, metric, base_model):
-    mock_get.return_value.status_code = 200
-    mock_get.return_value.json.return_value = {
-        "license": {"spdx_id": "GPL-3.0"}
-    }
+def test_unknown_license_from_huggingface(mock_get, metric, hf_model):
+    mock_get.return_value = Mock(status_code=200)
+    mock_get.return_value.json.return_value = {"cardData": {"license": "unknown"}}
 
-    base_model.codeLink = "https://github.com/someuser/somerepo"
-    score = metric.evaluate(base_model)
+    score = metric.evaluate(hf_model)
+    assert score == 0.5
+
+
+# Github Fallback Tests
+@patch("src.metrics.LicenseMetric.requests.get")
+def test_license_from_github_when_hf_fails(mock_get, metric, github_only_model):
+    # Simulate Hugging Face failure (1st call)
+    # Simulate GitHub success (2nd call)
+    def side_effect(url, *args, **kwargs):
+        if "huggingface.co" in url:
+            return Mock(status_code=404)
+        elif "github.com" in url:
+            m = Mock(status_code=200)
+            m.json.return_value = {"license": {"spdx_id": "GPL-3.0"}}
+            return m
+        return Mock(status_code=404)
+
+    mock_get.side_effect = side_effect
+
+    score = metric.evaluate(github_only_model)
     assert score == 0.0
 
 
+# Fallthrough / Error Cases
 @patch("src.metrics.LicenseMetric.requests.get")
-def test_unknown_license(mock_get, metric, base_model):
-    mock_get.return_value.status_code = 200
-    mock_get.return_value.json.return_value = {
-        "license": {"spdx_id": "Some-Weird-License"}
-    }
+def test_no_license_available(mock_get, metric, github_only_model):
+    mock_get.return_value = Mock(status_code=404)  # Both HF and GitHub fail
 
-    base_model.codeLink = "https://github.com/someuser/somerepo"
-    score = metric.evaluate(base_model)
+    score = metric.evaluate(github_only_model)
     assert score == 0.5
 
 
-@patch("src.metrics.LicenseMetric.requests.get")
-def test_no_license_field(mock_get, metric, base_model):
-    mock_get.return_value.status_code = 200
-    mock_get.return_value.json.return_value = {}
-
-    base_model.codeLink = "https://github.com/someuser/somerepo"
-    score = metric.evaluate(base_model)
+def test_no_links(metric):
+    model = StubModelData(modelLink="", codeLink="", datasetLink="")
+    score = metric.evaluate(model)
     assert score == 0.5
 
 
-def test_non_github_url(metric, base_model):
-    base_model.codeLink = "https://gitlab.com/some/repo"
-    score = metric.evaluate(base_model)
+# Malformed URL Tests
+def test_malformed_model_url(metric):
+    model = StubModelData(
+        modelLink="https://huggingface.co/",  # Invalid: no repo ID
+        codeLink="",  # No fallback
+        datasetLink=""
+    )
+    score = metric.evaluate(model)
     assert score == 0.5
 
 
-def test_empty_code_link(metric, base_model):
-    base_model.codeLink = ""
-    score = metric.evaluate(base_model)
+def test_non_hf_model_url(metric):
+    model = StubModelData(
+        modelLink="not-a-real-url",
+        codeLink="",  # No fallback
+        datasetLink=""
+    )
+    score = metric.evaluate(model)
+    assert score == 0.5
+
+
+def test_malformed_github_url(metric):
+    model = StubModelData(
+        modelLink="",  # No HF check
+        codeLink="https://github.com/just-owner",  # Invalid GitHub URL
+        datasetLink=""
+    )
+    score = metric.evaluate(model)
+    assert score == 0.5
+
+
+def test_non_github_code_url(metric):
+    model = StubModelData(
+        modelLink="",  # No HF check
+        codeLink="https://gitlab.com/org/repo",  # Unsupported provider
+        datasetLink=""
+    )
+    score = metric.evaluate(model)
     assert score == 0.5

--- a/tests/test_license_metric.py
+++ b/tests/test_license_metric.py
@@ -1,7 +1,16 @@
 import pytest
 from unittest.mock import patch
+from dataclasses import dataclass
+from typing import Optional
 
 from src.metrics.LicenseMetric import LicenseMetric
+
+
+@dataclass
+class StubModelData:
+    modelLink: str
+    codeLink: Optional[str]
+    datasetLink: Optional[str]
 
 
 @pytest.fixture
@@ -9,53 +18,69 @@ def metric():
     return LicenseMetric()
 
 
+@pytest.fixture
+def base_model():
+    """Base stub model with common fields (overridden in tests)."""
+    return StubModelData(
+        modelLink="https://huggingface.co/some/model",
+        codeLink=None,
+        datasetLink="https://huggingface.co/datasets/some/dataset"
+    )
+
+
 @patch("src.metrics.LicenseMetric.requests.get")
-def test_compatible_license(mock_get, metric):
+def test_compatible_license(mock_get, metric, base_model):
     mock_get.return_value.status_code = 200
     mock_get.return_value.json.return_value = {
         "license": {"spdx_id": "MIT"}
     }
 
-    score = metric.evaluate(codeLink="https://github.com/someuser/somerepo")
+    base_model.codeLink = "https://github.com/someuser/somerepo"
+    score = metric.evaluate(base_model)
     assert score == 1.0
 
 
 @patch("src.metrics.LicenseMetric.requests.get")
-def test_incompatible_license(mock_get, metric):
+def test_incompatible_license(mock_get, metric, base_model):
     mock_get.return_value.status_code = 200
     mock_get.return_value.json.return_value = {
         "license": {"spdx_id": "GPL-3.0"}
     }
 
-    score = metric.evaluate(codeLink="https://github.com/someuser/somerepo")
+    base_model.codeLink = "https://github.com/someuser/somerepo"
+    score = metric.evaluate(base_model)
     assert score == 0.0
 
 
 @patch("src.metrics.LicenseMetric.requests.get")
-def test_unknown_license(mock_get, metric):
+def test_unknown_license(mock_get, metric, base_model):
     mock_get.return_value.status_code = 200
     mock_get.return_value.json.return_value = {
-        "license": {"spdx_id": "Some-Strange-License"}
+        "license": {"spdx_id": "Some-Weird-License"}
     }
 
-    score = metric.evaluate(codeLink="https://github.com/someuser/somerepo")
+    base_model.codeLink = "https://github.com/someuser/somerepo"
+    score = metric.evaluate(base_model)
     assert score == 0.5
 
 
 @patch("src.metrics.LicenseMetric.requests.get")
-def test_no_license_field(mock_get, metric):
+def test_no_license_field(mock_get, metric, base_model):
     mock_get.return_value.status_code = 200
     mock_get.return_value.json.return_value = {}
 
-    score = metric.evaluate(codeLink="https://github.com/someuser/somerepo")
+    base_model.codeLink = "https://github.com/someuser/somerepo"
+    score = metric.evaluate(base_model)
     assert score == 0.5
 
 
-def test_non_github_url(metric):
-    score = metric.evaluate(codeLink="https://gitlab.com/some/repo")
+def test_non_github_url(metric, base_model):
+    base_model.codeLink = "https://gitlab.com/some/repo"
+    score = metric.evaluate(base_model)
     assert score == 0.5
 
 
-def test_empty_code_link(metric):
-    score = metric.evaluate(codeLink="")
+def test_empty_code_link(metric, base_model):
+    base_model.codeLink = ""
+    score = metric.evaluate(base_model)
     assert score == 0.5

--- a/tests/test_net_score.py
+++ b/tests/test_net_score.py
@@ -1,0 +1,69 @@
+"""
+Unit tests for computing NetScore in the Model class.
+"""
+
+import pytest
+from src.Model import Model
+from src.util.URLBundler import URLBundle
+
+
+def make_mock_model(evals: dict) -> Model:
+    """Helper to create a Model with predefined evaluation scores."""
+    urls = URLBundle(
+        model="https://huggingface.co/models/foo",
+        code="https://github.com/foo/bar",
+        dataset="https://huggingface.co/datasets/bar"
+    )
+    model = Model(urls)
+    model.evaluations = evals
+    return model
+
+
+@pytest.mark.parametrize("evals, expected", [
+    # All metrics present
+    ({
+        "LicenseMetric": 1.0,
+        "SizeMetric": {"average": 0.9},
+        "RampUpMetric": 0.8,
+        "BusFactorMetric": 0.7,
+        "AvailabilityMetric": 0.6,
+        "DatasetQualityMetric": 0.5,
+        "CodeQualityMetric": 0.4,
+        "PerformanceClaimsMetric": 0.3
+    }, 1.0 * (0.2 * 0.9 + 0.3 * 0.8 + 0.1 * 0.7 + 0.1 * 0.6 + 0.1 * 0.5 + 0.1 * 0.4 +
+              0.1 * 0.3)),
+
+    # Missing metrics default to 0.0
+    ({
+        "LicenseMetric": 0.5,
+        "SizeMetric": {"average": 0.8},
+        "RampUpMetric": 0.6
+    }, 0.5 * (0.2 * 0.8 + 0.3 * 0.6)),
+
+    # No LicenseMetric -> NetScore is 0
+    ({
+        "SizeMetric": {"average": 1.0},
+        "RampUpMetric": 1.0,
+        "BusFactorMetric": 1.0,
+        "AvailabilityMetric": 1.0,
+        "DatasetQualityMetric": 1.0,
+        "CodeQualityMetric": 1.0,
+        "PerformanceClaimsMetric": 1.0
+    }, 0.0),
+
+    # SizeMetric missing "average" key -> treat as 0.0
+    ({
+        "LicenseMetric": 1.0,
+        "SizeMetric": {},  # Missing "average"
+        "RampUpMetric": 1.0,
+        "BusFactorMetric": 1.0,
+        "AvailabilityMetric": 1.0,
+        "DatasetQualityMetric": 1.0,
+        "CodeQualityMetric": 1.0,
+        "PerformanceClaimsMetric": 1.0
+    }, 1.0 * (0.3 * 1.0 + 0.1 * 1.0 + 0.1 * 1.0 + 0.1 * 1.0 + 0.1 * 1.0 + 0.1 * 1.0)),
+])
+def test_compute_netscore(evals, expected):
+    model = make_mock_model(evals)
+    actual = model.computeNetScore()
+    assert actual == pytest.approx(expected, abs=1e-6)


### PR DESCRIPTION
- Created a ModelData Protocol
- Model inherits from ModelData
- Changed Metric.evaluate() signature to accept ModelData instead of three URL strings
- Added NetScore computation
- Added NetScore unit tests
- Updated LicenseMetric to prefer HuggingFace/model licenses over Github/code licenses
  - Still uses Github/code licenses as a fallback
- Updated LicenseMetric unit tests to test new preference/fallback