### PR TITLE
Implemented Model.name as property

### DIFF
--- a/src/Model.py
+++ b/src/Model.py
@@ -16,8 +16,6 @@ class Model(ModelData):
         self,
         urls: URLBundle
     ):
-        self.name = None
-
         self.modelLink: str = urls.model
         self.codeLink: Optional[str] = urls.code
         self.datasetLink: Optional[str] = urls.dataset
@@ -32,6 +30,10 @@ class Model(ModelData):
         """
         self.evaluations: dict[str, Union[float, dict[str, float]]] = {}
         self.evaluationsLatency: dict[str, float] = {}
+
+    @property
+    def name(self) -> str:
+        return self.hf_metadata.get("id", "").split("/")[1]
 
     @property
     def hf_metadata(self) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
- Model does not compute name on instantiation
- Model.name implemented as property
  - Extracts model name from HuggingFace metadata
  - Relies on hf_metadata property
  - Avoids API request at Model initialization