### PR TITLE
Enforced PEP8 and type annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,3 @@
-#Example from ChatGPT. Might need to edit for our purposes.
-
 [tool.pytest.ini_options]
 # Directories where tests live
 testpaths = ["tests"]
@@ -12,6 +10,22 @@ python_files = "test_*.py"
 # Maximum line length for code
 max-line-length = 88
 # Directories/files to exclude from linting
-exclude = [".venv", "__pycache__", "build", "dist"]
-# Ignore unused import warning in test_basic.py
-per-file-ignores = "tests/test_basic.py:F401"
+exclude = [".venv", "__pycache__", "build", "dist", ".git"]
+# Relax type annotation and import rules for test files
+per-file-ignores = [
+    "tests/*:F401,ANN201,ANN001,ANN401",  # Allow unused imports, missing return types, missing arg types, and Any usage in tests
+]
+extend-ignore = [
+    "E203",  # Whitespace before ':' (conflicts with Black formatter)
+    "W503",  # Line break before binary operator (old style)
+    "ANN101", # Missing type annotation for 'self' (redundant)
+    "ANN102", # Missing type annotation for 'cls' (redundant)
+]
+
+[tool.mypy]
+python_version = "3.11"
+# Require type annotations for variables
+disallow_untyped_defs = true
+disallow_any_unimported = true
+disallow_incomplete_defs = true
+show_error_codes = true

--- a/requirements-linting.txt
+++ b/requirements-linting.txt
@@ -1,0 +1,10 @@
+# Development dependencies
+flake8>=6.0.0
+flake8-annotations>=3.0.0
+mypy>=1.0.0
+black>=23.0.0
+types-requests>=2.28.0
+pytest>=7.0.0
+
+# Include main requirements
+-r requirements.txt

--- a/src/ModelCatalogue.py
+++ b/src/ModelCatalogue.py
@@ -19,7 +19,7 @@ class ModelCatalogue:
     # models holds all Model instances in the catalogue.
     # metrics holds all Metric instances to be applied to models.
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.models: list[Model] = []
         self.metrics: list[Metric] = [
             LicenseMetric(),
@@ -32,7 +32,7 @@ class ModelCatalogue:
             RampUpMetric()
         ]
 
-    def addModel(self, model: Model):
+    def addModel(self, model: Model) -> None:
         self.models.append(model)
 
         logger.debug(
@@ -45,11 +45,11 @@ class ModelCatalogue:
             model.codeLink
         )
 
-    def evaluateModels(self):
+    def evaluateModels(self) -> None:
         for model in self.models:
             model.evaluate_all(self.metrics)
 
-    def generateReport(self):
+    def generateReport(self) -> str:
         ndjson_report = []
         for model in self.models:
             ndjson_report.append(self.getModelNDJSON(model))

--- a/src/main.py
+++ b/src/main.py
@@ -11,33 +11,37 @@ from src.ModelCatalogue import ModelCatalogue
 def validate_github_token() -> bool:
     """
     Validate the GITHUB_TOKEN environment variable.
-    
+
     Returns:
         bool: True if token is valid, False otherwise
     """
     github_token = os.getenv("GITHUB_TOKEN")
-    
+
     if not github_token:
         logger.error("GITHUB_TOKEN environment variable is not set")
         return False
-    
+
     try:
         # Test token with a simple API call
         headers = {
             "Accept": "application/vnd.github.v3+json",
             "Authorization": f"token {github_token}"
         }
-        
+
         # Use a simple API call to validate the token
-        response = requests.get("https://api.github.com/user", headers=headers, timeout=10)
-        
+        response = requests.get(
+            "https://api.github.com/user", headers=headers, timeout=10
+        )
+
         if response.status_code == 200:
             logger.info("GitHub token is valid")
             return True
         else:
-            logger.error(f"GitHub token validation failed with status {response.status_code}")
+            logger.error(
+                f"GitHub token validation failed with status {response.status_code}"
+            )
             return False
-            
+
     except requests.exceptions.RequestException as e:
         logger.error(f"Error validating GitHub token: {e}")
         return False
@@ -58,7 +62,7 @@ def run_catalogue(file_path: str) -> int:
     if not validate_github_token():
         logger.error("Invalid or missing GITHUB_TOKEN. Exiting.")
         return 1
-    
+
     logger.info(f"Running model catalogue on file: {file_path}")
     catalogue = ModelCatalogue()
     success = True
@@ -105,7 +109,7 @@ def run_catalogue(file_path: str) -> int:
     return 0 if success else 1
 
 
-def configure_logging():
+def configure_logging() -> None:
     logger.remove()
     log_level_env = os.getenv("LOG_LEVEL", "0").strip()
     log_file = os.getenv("LOG_FILE", "").strip()

--- a/src/metrics/BusFactorMetric.py
+++ b/src/metrics/BusFactorMetric.py
@@ -21,9 +21,9 @@ class BusFactorMetric(Metric):
         author = ""
         if hf_metadata:
             author = (
-                hf_metadata.get("author") or
-                hf_metadata.get("id", "").split("/")[0] or
-                ""
+                hf_metadata.get("author")
+                or hf_metadata.get("id", "").split("/")[0]
+                or ""
             )
         logger.debug("Extracted author from HuggingFace metadata: '{}'", author)
 

--- a/src/metrics/CodeQualityMetric.py
+++ b/src/metrics/CodeQualityMetric.py
@@ -212,9 +212,9 @@ class CodeQualityMetric(Metric):
         )
 
         doc_score: float = (
-            (0.05 if has_license else 0.0) +
-            (0.05 if has_readme else 0.0) +
-            (0.10 if has_contributing else 0.0)
+            (0.05 if has_license else 0.0)
+            + (0.05 if has_readme else 0.0)
+            + (0.10 if has_contributing else 0.0)
         )
 
         found_docs: List[str] = []

--- a/src/metrics/DatasetQualityMetric.py
+++ b/src/metrics/DatasetQualityMetric.py
@@ -11,10 +11,12 @@ from src.Metric import Metric
 
 class DatasetQualityMetric(Metric):
     """
-    DatasetQualityMetric evaluates dataset quality using LLM analysis of dataset metadata.
+    DatasetQualityMetric evaluates dataset quality using
+    LLM analysis of dataset metadata.
 
     Scoring System:
-    Uses Purdue GenAI Studio's LLM to analyze dataset metadata and return a quality score
+    Uses Purdue GenAI Studio's LLM
+    to analyze dataset metadata and return a quality score
     from 0.0 to 1.0 based on factors like:
     - Dataset size and completeness
     - Documentation quality
@@ -64,18 +66,23 @@ class DatasetQualityMetric(Metric):
         metadata_json: str = json.dumps(metadata, indent=2)
 
         prompt: str = f"""
-You are an expert dataset evaluator. Analyze the following dataset metadata JSON and provide a quality score from 0.0 to 1.0.
+You are an expert dataset evaluator.
+Analyze the following dataset metadata JSON and provide a quality score from 0.0 to 1.0.
 
 Dataset Metadata:
 {metadata_json}
 
 Evaluation Criteria:
-1. Dataset Size & Completeness (0-0.3): File count, storage size, data volume, comprehensiveness
-2. Documentation Quality (0-0.3): Description clarity, metadata completeness, tags, categorization
-3. Community Engagement (0-0.2): Downloads, likes, usage indicators, popularity
-4. Maintenance & Recency (0-0.2): Last update, active maintenance, freshness
+1. Dataset Size & Completeness (0-0.3):
+    File count, storage size, data volume, comprehensiveness
+2. Documentation Quality (0-0.3): Description clarity, metadata completeness, tags,
+    categorization
+3. Community Engagement (0-0.2):
+    Downloads, likes, usage indicators, popularity
+4. Maintenance & Recency (0-0.2):
 
-Please provide ONLY a numerical score between 0.0 and 1.0 as your response. No explanation needed.
+Please provide ONLY a numerical score between 0.0 and 1.0 as your response.
+No explanation needed.
 """
 
         return prompt
@@ -97,7 +104,9 @@ Please provide ONLY a numerical score between 0.0 and 1.0 as your response. No e
             response = requests.post(self.api_url, headers=self.headers, json=body)
 
             if response.status_code != 200:
-                logger.error(f"API request failed: {response.status_code}, {response.text}")
+                logger.error(
+                    f"API request failed: {response.status_code}, {response.text}"
+                )
                 return None
 
             response_data: Dict[str, Any] = response.json()
@@ -112,7 +121,9 @@ Please provide ONLY a numerical score between 0.0 and 1.0 as your response. No e
                     logger.debug(f"LLM returned score: {score}")
                     return max(0.0, min(1.0, score))  # Clamp between 0 and 1
                 else:
-                    logger.warning(f"Could not parse score from LLM response: {content}")
+                    logger.warning(
+                        f"Could not parse score from LLM response: {content}"
+                    )
 
             return None
 

--- a/src/metrics/LicenseMetric.py
+++ b/src/metrics/LicenseMetric.py
@@ -1,4 +1,5 @@
 from loguru import logger
+from typing import Any
 
 from src.Interfaces import ModelData
 from src.Metric import Metric
@@ -39,7 +40,7 @@ class LicenseMetric(Metric):
             float: Score from 0.0 (incompatible) to 1.0 (fully compatible).
         """
         logger.debug("Evaluating LicenseMetric...")
-        license_id = None
+        license_id : Any = None  # license_id is returned as Any from metadata
 
         # Step 1: Try HuggingFace metadata
         if model.modelLink and "huggingface.co" in model.modelLink:
@@ -61,7 +62,9 @@ class LicenseMetric(Metric):
                 license_info = gh_meta if isinstance(gh_meta, dict) else {}
                 license_id = license_info.get("license", "")
                 if license_id:
-                    logger.debug("License found in GitHub metadata: {}", license_id)
+                    logger.debug(
+                        "License found in GitHub metadata: {}", license_id
+                    )
 
         # Step 3: Map license to score
         license_score = self.LICENSE_COMPATIBILITY.get(license_id, 0.5)

--- a/src/metrics/PerformanceClaimsMetric.py
+++ b/src/metrics/PerformanceClaimsMetric.py
@@ -98,7 +98,7 @@ class PerformanceClaimsMetric(Metric):
 
     def _extract_hf_claims(self, model: ModelData) -> List[Dict[str, Any]]:
         """Extract performance claims from HuggingFace metadata."""
-        claims = []
+        claims: List[Dict[str, Any]] = []
 
         try:
             hf_meta = model.hf_metadata
@@ -140,7 +140,7 @@ class PerformanceClaimsMetric(Metric):
 
     def _extract_github_claims(self, model: ModelData) -> List[Dict[str, Any]]:
         """Extract performance claims from GitHub metadata."""
-        claims = []
+        claims: List[Dict[str, Any]] = []
 
         try:
             gh_meta = model.github_metadata
@@ -164,7 +164,7 @@ class PerformanceClaimsMetric(Metric):
 
     def _find_performance_claims(self, text: str) -> List[Dict[str, Any]]:
         """Find performance claims in text using regex patterns."""
-        claims = []
+        claims: List[Dict[str, Any]] = []
 
         if not text or not isinstance(text, str):
             return claims

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ def base_model() -> StubModelData:
     return StubModelData(
         modelLink="https://huggingface.co/microsoft/DialoGPT-medium",
         codeLink="https://github.com/huggingface/transformers",
-        datasetLink="https://huggingface.co/datasets/squad"
+        datasetLink="https://huggingface.co/datasets/squad",
     )
 
 
@@ -75,7 +75,7 @@ def sample_urls() -> list[str]:
     return [
         "https://huggingface.co/datasets/squad",
         "https://github.com/huggingface/transformers",
-        "https://huggingface.co/microsoft/DialoGPT-medium"
+        "https://huggingface.co/microsoft/DialoGPT-medium",
     ]
 
 
@@ -84,6 +84,7 @@ def intercept_loguru_logs(caplog):
     """
     Redirect loguru logs to standard logging so pytest caplog can capture them.
     """
+
     class PropagateHandler(logging.Handler):
         def emit(self, record):
             logging.getLogger(record.name).handle(record)

--- a/tests/metric_tests/test_metadata_fetchers.py
+++ b/tests/metric_tests/test_metadata_fetchers.py
@@ -15,8 +15,7 @@ def test_huggingface_fetcher_success():
     metadata = fetcher.fetch_metadata(url)
 
     session.get.assert_called_once_with(
-        "https://huggingface.co/api/models/organization/model-id",
-        timeout=5
+        "https://huggingface.co/api/models/organization/model-id", timeout=5
     )
     assert metadata == {"id": "model-id", "downloads": 1000}
 
@@ -60,18 +59,18 @@ def test_github_fetcher_success():
     repo_response.json.return_value = {
         "clone_url": "https://github.com/org/repo.git",
         "stargazers_count": 100,
-        "forks_count": 50
+        "forks_count": 50,
     }
 
     # Mock commit activity response
     commit_response = MagicMock(ok=True)
-    commit_response.json.return_value = [{}]*150  # 150 commits in last 30 days
+    commit_response.json.return_value = [{}] * 150  # 150 commits in last 30 days
 
     session.get.side_effect = [
         contrib_response,
         license_response,
         repo_response,
-        commit_response
+        commit_response,
     ]
 
     fetcher = GitHubFetcher(session=session)
@@ -84,7 +83,7 @@ def test_github_fetcher_success():
         "clone_url": "https://github.com/org/repo.git",
         "stargazers_count": 100,
         "forks_count": 50,
-        "avg_daily_commits_30d": 5
+        "avg_daily_commits_30d": 5,
     }
     assert session.get.call_count == 4
 
@@ -124,18 +123,18 @@ def test_github_fetcher_partial_failure():
     repo_response.json.return_value = {
         "clone_url": "https://github.com/org/repo.git",
         "stargazers_count": 100,
-        "forks_count": 50
+        "forks_count": 50,
     }
 
     # Commit response succeeds
     commit_response = MagicMock(ok=True)
-    commit_response.json.return_value = [{}]*150  # 150 commits in last 30 days
+    commit_response.json.return_value = [{}] * 150  # 150 commits in last 30 days
 
     session.get.side_effect = [
         contrib_response,
         license_response,
         repo_response,
-        commit_response
+        commit_response,
     ]
 
     fetcher = GitHubFetcher(session=session)
@@ -146,7 +145,7 @@ def test_github_fetcher_partial_failure():
         "clone_url": "https://github.com/org/repo.git",
         "stargazers_count": 100,
         "forks_count": 50,
-        "avg_daily_commits_30d": 5
+        "avg_daily_commits_30d": 5,
     }
     assert session.get.call_count == 4
 
@@ -164,8 +163,7 @@ def test_dataset_fetcher_success():
     metadata = fetcher.fetch_metadata(url)
 
     session.get.assert_called_once_with(
-        "https://huggingface.co/api/datasets/xlangai/AgentNet",
-        timeout=5
+        "https://huggingface.co/api/datasets/xlangai/AgentNet", timeout=5
     )
     assert metadata == {"id": "dataset-id", "downloads": 5000}
 

--- a/tests/metric_tests/test_performance_claims_metric.py
+++ b/tests/metric_tests/test_performance_claims_metric.py
@@ -1,7 +1,7 @@
 """
 Unit tests for the PerformanceClaimsMetric class.
 """
-from unittest.mock import Mock, patch
+
 import pytest
 
 from src.metrics.PerformanceClaimsMetric import PerformanceClaimsMetric
@@ -18,15 +18,15 @@ def hf_model():
     model = StubModelData(
         modelLink="https://huggingface.co/facebook/bart-large",
         codeLink="https://github.com/huggingface/transformers",
-        datasetLink="https://huggingface.co/datasets/squad"
+        datasetLink="https://huggingface.co/datasets/squad",
     )
     # Mock the metadata properties
     model.hf_metadata = {
         "cardData": {
             "model_description": "This model achieves 95% accuracy on ImageNet",
-            "model_summary": "High performance model with 0.92 F1 score"
+            "model_summary": "High performance model with 0.92 F1 score",
         },
-        "tags": ["accuracy", "imagenet"]
+        "tags": ["accuracy", "imagenet"],
     }
     return model
 
@@ -36,12 +36,10 @@ def github_only_model():
     model = StubModelData(
         modelLink="https://somewhere.else/model",
         codeLink="https://github.com/someuser/somerepo",
-        datasetLink=None
+        datasetLink=None,
     )
     # Mock the metadata properties
-    model.github_metadata = {
-        "description": "Model with 94% accuracy on GLUE benchmark"
-    }
+    model.github_metadata = {"description": "Model with 94% accuracy on GLUE benchmark"}
     return model
 
 
@@ -57,15 +55,15 @@ def test_hf_claims_with_benchmark(metric):
     model = StubModelData(
         modelLink="https://huggingface.co/facebook/bart-large",
         codeLink=None,
-        datasetLink=None
+        datasetLink=None,
     )
     model.hf_metadata = {
         "cardData": {
             "model_description": "Achieves 88.5 BLEU score on WMT dataset",
-            "training_data": "Trained on Common Crawl and Wikipedia"
+            "training_data": "Trained on Common Crawl and Wikipedia",
         }
     }
-    
+
     score = metric.evaluate(model)
     assert score > 0.0
 
@@ -75,16 +73,16 @@ def test_hf_no_claims(metric):
     model = StubModelData(
         modelLink="https://huggingface.co/facebook/bart-large",
         codeLink=None,
-        datasetLink=None
+        datasetLink=None,
     )
     model.hf_metadata = {
         "cardData": {
             "model_description": "A general purpose language model",
-            "model_summary": "Useful for various NLP tasks"
+            "model_summary": "Useful for various NLP tasks",
         },
-        "tags": ["pytorch", "transformers"]
+        "tags": ["pytorch", "transformers"],
     }
-    
+
     score = metric.evaluate(model)
     assert score == 0.0
 
@@ -101,12 +99,12 @@ def test_github_no_claims(metric):
     model = StubModelData(
         modelLink="https://somewhere.else/model",
         codeLink="https://github.com/someuser/somerepo",
-        datasetLink=None
+        datasetLink=None,
     )
     model.github_metadata = {
         "description": "A simple Python library for machine learning"
     }
-    
+
     score = metric.evaluate(model)
     assert score == 0.0
 
@@ -115,13 +113,13 @@ def test_github_no_claims(metric):
 def test_claim_scoring_quantified_with_benchmark():
     """Test scoring of quantified claims with benchmark context."""
     metric = PerformanceClaimsMetric()
-    
+
     claim = {
-        'text': '95% accuracy on imagenet',
-        'source': 'test',
-        'context': 'performance metric'
+        "text": "95% accuracy on imagenet",
+        "source": "test",
+        "context": "performance metric",
     }
-    
+
     score = metric._score_claim(claim)
     assert score == 1.0
 
@@ -129,13 +127,9 @@ def test_claim_scoring_quantified_with_benchmark():
 def test_claim_scoring_quantified_without_benchmark():
     """Test scoring of quantified claims without benchmark context."""
     metric = PerformanceClaimsMetric()
-    
-    claim = {
-        'text': '92% f1 score',
-        'source': 'test',
-        'context': 'performance metric'
-    }
-    
+
+    claim = {"text": "92% f1 score", "source": "test", "context": "performance metric"}
+
     score = metric._score_claim(claim)
     assert score == 0.8
 
@@ -143,13 +137,13 @@ def test_claim_scoring_quantified_without_benchmark():
 def test_claim_scoring_vague_with_benchmark():
     """Test scoring of vague claims with benchmark context."""
     metric = PerformanceClaimsMetric()
-    
+
     claim = {
-        'text': 'high accuracy on squad',
-        'source': 'test',
-        'context': 'performance metric'
+        "text": "high accuracy on squad",
+        "source": "test",
+        "context": "performance metric",
     }
-    
+
     score = metric._score_claim(claim)
     assert score == 0.6
 
@@ -157,13 +151,13 @@ def test_claim_scoring_vague_with_benchmark():
 def test_claim_scoring_benchmark_only():
     """Test scoring of benchmark mentions without specific metrics."""
     metric = PerformanceClaimsMetric()
-    
+
     claim = {
-        'text': 'trained on imagenet',
-        'source': 'test',
-        'context': 'benchmark dataset'
+        "text": "trained on imagenet",
+        "source": "test",
+        "context": "benchmark dataset",
     }
-    
+
     score = metric._score_claim(claim)
     assert score == 0.2
 
@@ -172,7 +166,7 @@ def test_claim_scoring_benchmark_only():
 def test_performance_pattern_matching():
     """Test that performance patterns are correctly identified."""
     metric = PerformanceClaimsMetric()
-    
+
     test_texts = [
         "95% accuracy",
         "F1: 0.92",
@@ -180,9 +174,9 @@ def test_performance_pattern_matching():
         "BLEU score of 0.85",
         "ROUGE-L: 0.78",
         "Perplexity: 15.2",
-        "Loss: 0.05"
+        "Loss: 0.05",
     ]
-    
+
     for text in test_texts:
         claims = metric._find_performance_claims(text)
         assert len(claims) > 0, f"Failed to find claims in: {text}"
@@ -191,7 +185,7 @@ def test_performance_pattern_matching():
 def test_benchmark_pattern_matching():
     """Test that benchmark patterns are correctly identified."""
     metric = PerformanceClaimsMetric()
-    
+
     test_texts = [
         "trained on ImageNet",
         "evaluated on GLUE",
@@ -199,9 +193,9 @@ def test_benchmark_pattern_matching():
         "WMT translation",
         "COCO object detection",
         "VQA visual question answering",
-        "MS MARCO passage ranking"
+        "MS MARCO passage ranking",
     ]
-    
+
     for text in test_texts:
         claims = metric._find_performance_claims(text)
         assert len(claims) > 0, f"Failed to find benchmark claims in: {text}"
@@ -213,10 +207,10 @@ def test_network_error_handling(metric):
     model = StubModelData(
         modelLink="https://huggingface.co/facebook/bart-large",
         codeLink=None,
-        datasetLink=None
+        datasetLink=None,
     )
     model.hf_metadata = None  # Simulate network error
-    
+
     score = metric.evaluate(model)
     assert score == 0.0
 
@@ -226,10 +220,10 @@ def test_invalid_json_response(metric):
     model = StubModelData(
         modelLink="https://huggingface.co/facebook/bart-large",
         codeLink=None,
-        datasetLink=None
+        datasetLink=None,
     )
     model.hf_metadata = {"invalid": "data"}  # Invalid structure
-    
+
     score = metric.evaluate(model)
     assert score == 0.0
 
@@ -237,7 +231,7 @@ def test_invalid_json_response(metric):
 def test_no_urls_provided(metric):
     """Test when no URLs are provided."""
     model = StubModelData(modelLink="", codeLink="", datasetLink="")
-    
+
     score = metric.evaluate(model)
     assert score == 0.0
 
@@ -246,10 +240,10 @@ def test_no_urls_provided(metric):
 def test_empty_text_fields():
     """Test handling of empty text fields."""
     metric = PerformanceClaimsMetric()
-    
+
     claims = metric._find_performance_claims("")
     assert len(claims) == 0
-    
+
     claims = metric._find_performance_claims(None)
     assert len(claims) == 0
 
@@ -257,12 +251,10 @@ def test_empty_text_fields():
 def test_malformed_metadata(metric):
     """Test handling of malformed metadata."""
     model = StubModelData(
-        modelLink="https://huggingface.co/test/model",
-        codeLink=None,
-        datasetLink=None
+        modelLink="https://huggingface.co/test/model", codeLink=None, datasetLink=None
     )
     model.hf_metadata = {"invalid": "data"}
-    
+
     score = metric.evaluate(model)
     assert score == 0.0
 
@@ -273,14 +265,14 @@ def test_multiple_claims_averaging(metric):
     model = StubModelData(
         modelLink="https://huggingface.co/facebook/bart-large",
         codeLink=None,
-        datasetLink=None
+        datasetLink=None,
     )
     model.hf_metadata = {
         "cardData": {
             "model_description": "95% accuracy on ImageNet, 92% F1 on GLUE",
-            "model_summary": "High performance model"
+            "model_summary": "High performance model",
         }
     }
-    
+
     score = metric.evaluate(model)
     assert 0.0 < score < 1.0  # Should be between 0 and 1

--- a/tests/metric_tests/test_size_metric.py
+++ b/tests/metric_tests/test_size_metric.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import Mock, patch
+from typing import Optional, Any
 from src.metrics.SizeMetric import SizeMetric
 from src.Interfaces import ModelData
 
@@ -23,7 +24,7 @@ class TestSizeMetric:
         mock_model.hf_metadata = {
             "config": {
                 "num_parameters": 7_000_000_000,  # 7B parameters
-                "name_or_path": "test/model-7b"
+                "name_or_path": "test/model-7b",
             }
         }
         return mock_model
@@ -37,12 +38,10 @@ class TestSizeMetric:
         scores = metric.evaluate(model_with_metadata)
 
         assert len(scores) == 4
-        assert all(device in scores for device in [
-            "raspberry_pi",
-            "jetson_nano",
-            "desktop_pc",
-            "aws_server"
-        ])
+        assert all(
+            device in scores
+            for device in ["raspberry_pi", "jetson_nano", "desktop_pc", "aws_server"]
+        )
         assert all(0.0 <= score <= 1.0 for score in scores.values())
 
     def test_evaluate_no_metadata(self, metric: SizeMetric, mock_model: Mock) -> None:
@@ -54,7 +53,7 @@ class TestSizeMetric:
             "raspberry_pi": 0.0,
             "jetson_nano": 0.0,
             "desktop_pc": 0.0,
-            "aws_server": 0.0
+            "aws_server": 0.0,
         }
         assert scores == expected
 
@@ -76,7 +75,7 @@ class TestSizeMetric:
         # All devices should get high scores
         assert all(score > 0.8 for score in scores.values())
 
-    @patch.object(SizeMetric, '_get_model_size')
+    @patch.object(SizeMetric, "_get_model_size")
     def test_evaluate_error_handling(
         self, mock_get_size: Mock, metric: SizeMetric, mock_model: Mock
     ) -> None:
@@ -88,7 +87,7 @@ class TestSizeMetric:
             "raspberry_pi": 0.0,
             "jetson_nano": 0.0,
             "desktop_pc": 0.0,
-            "aws_server": 0.0
+            "aws_server": 0.0,
         }
         assert scores == expected
 
@@ -98,8 +97,9 @@ class TestSizeMetric:
         self, metric: SizeMetric, model_with_metadata: Mock
     ) -> None:
         """Test successful model size calculation."""
-        size_gb = metric._get_model_size(model_with_metadata)
+        size_gb : Optional[float] = metric._get_model_size(model_with_metadata)
 
+        assert size_gb is not None
         # 7B params * 2 bytes = 14GB / 1024^3 ≈ 13.04GB
         assert 13.0 <= size_gb <= 14.0  # 7B * 2 bytes ≈ 13GB
 
@@ -111,17 +111,19 @@ class TestSizeMetric:
         mock_model.hf_metadata = {
             "config": {"num_parameters": 1_000_000_000, "torch_dtype": "float32"}
         }
-        size_gb = metric._get_model_size(mock_model)
+        size_gb : Optional[float] = metric._get_model_size(mock_model)
+        assert size_gb is not None
         assert 3.5 <= size_gb <= 4.0  # 1B * 4 bytes ≈ 3.7GB
 
         # Quantized model
         mock_model.hf_metadata = {
             "config": {
                 "num_parameters": 7_000_000_000,
-                "quantization_config": {"bits": 8}
+                "quantization_config": {"bits": 8},
             }
         }
         size_gb = metric._get_model_size(mock_model)
+        assert size_gb is not None
         assert 6.0 <= size_gb <= 7.0  # 7B * 1 byte ≈ 6.5GB
 
     def test_get_model_size_no_params(
@@ -133,35 +135,38 @@ class TestSizeMetric:
 
     # --- Tests for _extract_bytes_from_dtype() ---
 
-    @pytest.mark.parametrize("torch_dtype,expected_bytes", [
-        ("float32", 4.0),
-        ("float16", 2.0),
-        ("int8", 1.0),
-        ("int4", 0.5),
-        ("bfloat16", 2.0),
-        ("", 2.0),
-        (None, 2.0)  # Defaults
-    ])
+    @pytest.mark.parametrize(
+        "torch_dtype,expected_bytes",
+        [
+            ("float32", 4.0),
+            ("float16", 2.0),
+            ("int8", 1.0),
+            ("int4", 0.5),
+            ("bfloat16", 2.0),
+            ("", 2.0),
+            (None, 2.0),  # Defaults
+        ],
+    )
     def test_extract_bytes_from_dtype(
         self, metric: SizeMetric, torch_dtype: str, expected_bytes: float
     ) -> None:
         """Test dtype extraction from torch_dtype field."""
-        metadata = {"config": {"torch_dtype": torch_dtype}} if torch_dtype \
-            else {"config": {}}
+        metadata = (
+            {"config": {"torch_dtype": torch_dtype}} if torch_dtype else {"config": {}}
+        )
 
         assert metric._extract_bytes_from_dtype(metadata) == expected_bytes
 
     def test_extract_bytes_quantization_precedence(self, metric: SizeMetric) -> None:
         """Test dtype extraction precedence and quantization."""
         # Quantization only
-        metadata = {"config": {"quantization_config": {"bits": 4}}}
+        metadata : dict[str, Any] = {"config": {"quantization_config": {"bits": 4}}}
         assert metric._extract_bytes_from_dtype(metadata) == 0.5
 
         # torch_dtype takes precedence over quantization
-        metadata = {"config": {
-            "torch_dtype": "float32",
-            "quantization_config": {"bits": 8}
-        }}
+        metadata = {
+            "config": {"torch_dtype": "float32", "quantization_config": {"bits": 8}}
+        }
         assert metric._extract_bytes_from_dtype(metadata) == 4.0
 
     # --- Tests for _get_parameter_count() ---
@@ -186,28 +191,33 @@ class TestSizeMetric:
         """Test parameter extraction edge cases."""
         # Invalid values
         assert metric._get_parameter_count({"config": {"num_parameters": -1}}) is None
-        assert metric._get_parameter_count(
-            {"config": {"num_parameters": "invalid"}}
-        ) is None
+        assert (
+            metric._get_parameter_count({"config": {"num_parameters": "invalid"}})
+            is None
+        )
 
         # No valid fields
-        assert metric._get_parameter_count(
-            {"config": {"model_type": "transformer"}}
-        ) is None
+        assert (
+            metric._get_parameter_count({"config": {"model_type": "transformer"}})
+            is None
+        )
         assert metric._get_parameter_count({"other_field": "value"}) is None
 
     # --- Tests for _extract_params_from_name() ---
 
-    @pytest.mark.parametrize("model_name,expected_params", [
-        ("llama-7b", 7_000_000_000),
-        ("gpt-3.5b", 3_500_000_000),
-        ("model-13B", 13_000_000_000),
-        ("falcon-40b-instruct", 40_000_000_000),
-        ("bert-110M", None),  # 'M' not supported, only 'b'/'B'
-        ("no-params-here", None),
-        ("model-7.5b-chat", 7_500_000_000),
-        ("70B-model", 70_000_000_000),
-    ])
+    @pytest.mark.parametrize(
+        "model_name,expected_params",
+        [
+            ("llama-7b", 7_000_000_000),
+            ("gpt-3.5b", 3_500_000_000),
+            ("model-13B", 13_000_000_000),
+            ("falcon-40b-instruct", 40_000_000_000),
+            ("bert-110M", None),  # 'M' not supported, only 'b'/'B'
+            ("no-params-here", None),
+            ("model-7.5b-chat", 7_500_000_000),
+            ("70B-model", 70_000_000_000),
+        ],
+    )
     def test_extract_params_from_name(
         self, metric: SizeMetric, model_name: str, expected_params: int
     ) -> None:
@@ -222,7 +232,7 @@ class TestSizeMetric:
             "raspberry_pi": 2.0,
             "jetson_nano": 3.0,
             "desktop_pc": 20.0,
-            "aws_server": 60.0
+            "aws_server": 60.0,
         }
         assert metric.DEVICE_SPECS == expected
 
@@ -249,14 +259,12 @@ class TestSizeMetric:
 
             # Over limit: score = 0
             score = max(
-                0.0,
-                min(1.0, (memory_limit - (memory_limit + 1)) / memory_limit)
+                0.0, min(1.0, (memory_limit - (memory_limit + 1)) / memory_limit)
             )
             assert score == 0.0
 
             # Under limit: score > 0
             score = max(
-                0.0,
-                min(1.0, (memory_limit - (memory_limit - 0.1)) / memory_limit)
+                0.0, min(1.0, (memory_limit - (memory_limit - 0.1)) / memory_limit)
             )
             assert score > 0.0

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,7 @@
 """
 Basic tests for the model-hub-cli project.
 """
+
 import sys
 
 import pytest
@@ -20,8 +21,7 @@ def test_imports():
 
 def test_python_version():
     """Test that we're using Python 3.8+."""
-    assert sys.version_info >= (3, 8), \
-           f"Python 3.8+ required, got {sys.version}"
+    assert sys.version_info >= (3, 8), f"Python 3.8+ required, got {sys.version}"
 
 
 def test_placeholder():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -89,9 +89,9 @@ def test_main_entrypoint_with_arg(
 
     test_argv = ["main.py", str(file_path)]
 
-    with patch("sys.argv", test_argv), \
-         patch("sys.exit") as mock_exit, \
-         patch("src.main.validate_github_token", return_value=True):
+    with patch("sys.argv", test_argv), patch("sys.exit") as mock_exit, patch(
+        "src.main.validate_github_token", return_value=True
+    ):
         main.configure_logging()
         # call main block code manually:
         if len(sys.argv) < 2:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -15,7 +15,7 @@ class ComplexDummyMetric(Metric):
             "raspberry_pi": 0.6,
             "jetson_nano": 0.6,
             "desktop_pc": 0.8,
-            "aws_server": 0.8
+            "aws_server": 0.8,
         }
 
 
@@ -66,7 +66,7 @@ def test_get_score_with_dict(sample_urls):
         "raspberry_pi": 0.6,
         "jetson_nano": 0.6,
         "desktop_pc": 0.8,
-        "aws_server": 0.8
+        "aws_server": 0.8,
     }
 
     assert model.getScore("ComplexDummyMetric") == expected_dict
@@ -85,13 +85,13 @@ def computeNetScore(self) -> float:
     avg_size_score = sum(size_score.values()) / len(size_score) if size_score else 0.0
 
     weighted_sum = (
-        0.2 * avg_size_score +
-        0.3 * rampup_score +
-        0.1 * bus_score +
-        0.1 * avail_score +
-        0.1 * data_qual_score +
-        0.1 * code_qual_score +
-        0.1 * perf_score
+        0.2 * avg_size_score
+        + 0.3 * rampup_score
+        + 0.1 * bus_score
+        + 0.1 * avail_score
+        + 0.1 * data_qual_score
+        + 0.1 * code_qual_score
+        + 0.1 * perf_score
     )
 
     net_score = license_score * weighted_sum
@@ -124,26 +124,26 @@ def test_compute_net_score_all_metrics_present(sample_urls):
             "raspberry_pi": 0.6,
             "jetson_nano": 0.6,
             "desktop_pc": 0.8,
-            "aws_server": 0.8
+            "aws_server": 0.8,
         },
         "RampUpMetric": 0.7,
         "BusFactorMetric": 0.8,
         "AvailabilityMetric": 0.9,
         "DatasetQualityMetric": 0.6,
         "CodeQualityMetric": 0.7,
-        "PerformanceClaimsMetric": 0.5
+        "PerformanceClaimsMetric": 0.5,
     }
 
     expected_size_avg = 0.7  # (0.6 + 0.6 + 0.8 + 0.8) / 4
 
     expected_weighted = (
-        0.2 * expected_size_avg +
-        0.3 * 0.7 +
-        0.1 * 0.8 +
-        0.1 * 0.9 +
-        0.1 * 0.6 +
-        0.1 * 0.7 +
-        0.1 * 0.5
+        0.2 * expected_size_avg
+        + 0.3 * 0.7
+        + 0.1 * 0.8
+        + 0.1 * 0.9
+        + 0.1 * 0.6
+        + 0.1 * 0.7
+        + 0.1 * 0.5
     )
 
     expected_score = round(1.0 * expected_weighted, 2)
@@ -161,14 +161,14 @@ def test_compute_net_score_missing_license_returns_zero(sample_urls):
             "raspberry_pi": 0.6,
             "jetson_nano": 0.6,
             "desktop_pc": 0.8,
-            "aws_server": 0.8
+            "aws_server": 0.8,
         },
         "RampUpMetric": 0.7,
         "BusFactorMetric": 0.8,
         "AvailabilityMetric": 0.9,
         "DatasetQualityMetric": 0.6,
         "CodeQualityMetric": 0.7,
-        "PerformanceClaimsMetric": 0.5
+        "PerformanceClaimsMetric": 0.5,
     }
 
     model.computeNetScore()
@@ -193,13 +193,13 @@ def test_compute_net_score_handles_missing_metrics_as_zero(sample_urls):
     }
 
     expected_weighted = (
-        0.2 * 0.0 +   # SizeMetric treated as 0
-        0.3 * 0.5 +
-        0.1 * 0.0 +   # BusFactorMetric treated as 0
-        0.1 * 0.7 +
-        0.1 * 0.6 +
-        0.1 * 0.65 +
-        0.1 * 0.0     # PerformanceClaimsMetric treated as 0
+        0.2 * 0.0  # SizeMetric treated as 0
+        + 0.3 * 0.5
+        + 0.1 * 0.0  # BusFactorMetric treated as 0
+        + 0.1 * 0.7
+        + 0.1 * 0.6
+        + 0.1 * 0.65
+        + 0.1 * 0.0  # PerformanceClaimsMetric treated as 0
     )
 
     expected_score = round(1.0 * expected_weighted, 2)
@@ -220,18 +220,18 @@ def test_compute_net_score_with_invalid_size_metric(sample_urls):
         "AvailabilityMetric": 0.9,
         "DatasetQualityMetric": 0.6,
         "CodeQualityMetric": 0.7,
-        "PerformanceClaimsMetric": 0.5
+        "PerformanceClaimsMetric": 0.5,
     }
 
     # Size gets treated as 0.0
     expected_weighted = (
-        0.0 +               # size
-        0.3 * 0.7 +
-        0.1 * 0.8 +
-        0.1 * 0.9 +
-        0.1 * 0.6 +
-        0.1 * 0.7 +
-        0.1 * 0.5
+        0.0  # size
+        + 0.3 * 0.7
+        + 0.1 * 0.8
+        + 0.1 * 0.9
+        + 0.1 * 0.6
+        + 0.1 * 0.7
+        + 0.1 * 0.5
     )
     expected_score = round(1.0 * expected_weighted, 2)
     model.computeNetScore()

--- a/tests/test_model_catalogue.py
+++ b/tests/test_model_catalogue.py
@@ -3,17 +3,19 @@ import json
 from unittest.mock import MagicMock
 
 from src.Metric import Metric
+from src.Interfaces import ModelData
 from src.Model import Model
 from src.ModelCatalogue import ModelCatalogue
 
 
 class StubMetric(Metric):
     """Metric that returns a constant float value."""
-    def __init__(self, name="StubMetric", value=0.42):
+
+    def __init__(self, name="StubMetric", value=0.42) -> None:
         self._name = name
         self._value = value
 
-    def evaluate(self, model: Model) -> float:
+    def evaluate(self, model: ModelData) -> float:
         return self._value
 
 
@@ -27,12 +29,13 @@ class StubMetric2(StubMetric):
 
 class StubSizeMetric(Metric):
     """Stub metric simulating SizeMetric device-specific scores."""
-    def evaluate(self, model: Model) -> dict[str, float]:
+
+    def evaluate(self, model: ModelData) -> dict[str, float]:
         return {
             "raspberry_pi": 0.6,
             "jetson_nano": 0.6,
             "desktop_pc": 0.8,
-            "aws_server": 0.8
+            "aws_server": 0.8,
         }
 
 
@@ -51,7 +54,7 @@ def test_evaluate_models_runs_all_metrics(sample_model):
 
     catalogue.metrics = [
         StubMetric1("StubMetric1", 0.3),
-        StubMetric2("StubMetric2", 0.7)
+        StubMetric2("StubMetric2", 0.7),
     ]
 
     catalogue.addModel(sample_model)
@@ -78,7 +81,7 @@ def test_generate_report_format(sample_model):
         StubMetric("DatasetQualityMetric", 0.6),
         StubMetric("CodeQualityMetric", 0.65),
         StubMetric("PerformanceClaimsMetric", 0.55),
-        StubSizeMetric()  # returns dict
+        StubSizeMetric(),  # returns dict
     ]
 
     catalogue.addModel(sample_model)
@@ -93,20 +96,31 @@ def test_generate_report_format(sample_model):
     assert isinstance(model_json, dict)
 
     expected_keys = {
-        "name", "category", "net_score", "net_score_latency",
-        "ramp_up_time", "ramp_up_time_latency",
-        "bus_factor", "bus_factor_latency",
-        "performance_claims", "performance_claims_latency",
-        "license", "license_latency",
-        "size_score", "size_score_latency",
-        "dataset_and_code_score", "dataset_and_code_score_latency",
-        "dataset_quality", "dataset_quality_latency",
-        "code_quality", "code_quality_latency",
+        "name",
+        "category",
+        "net_score",
+        "net_score_latency",
+        "ramp_up_time",
+        "ramp_up_time_latency",
+        "bus_factor",
+        "bus_factor_latency",
+        "performance_claims",
+        "performance_claims_latency",
+        "license",
+        "license_latency",
+        "size_score",
+        "size_score_latency",
+        "dataset_and_code_score",
+        "dataset_and_code_score_latency",
+        "dataset_quality",
+        "dataset_quality_latency",
+        "code_quality",
+        "code_quality_latency",
     }
 
-    assert expected_keys.issubset(model_json.keys()), (
-        f"Missing keys: {expected_keys - model_json.keys()}"
-    )
+    assert expected_keys.issubset(
+        model_json.keys()
+    ), f"Missing keys: {expected_keys - model_json.keys()}"
 
 
 def test_get_model_ndjson_defaults(sample_model):

--- a/tests/test_url_utils.py
+++ b/tests/test_url_utils.py
@@ -4,15 +4,14 @@ from src.util.url_utils import URLSet
 
 
 def test_classify_url_valid():
-    assert url_utils.classify_url(
-        "https://huggingface.co/datasets/squad"
-    ) == "dataset"
-    assert url_utils.classify_url(
-        "https://huggingface.co/microsoft/DialoGPT-medium"
-    ) == "model"
-    assert url_utils.classify_url(
-        "https://github.com/huggingface/transformers"
-    ) == "code"
+    assert url_utils.classify_url("https://huggingface.co/datasets/squad") == "dataset"
+    assert (
+        url_utils.classify_url("https://huggingface.co/microsoft/DialoGPT-medium")
+        == "model"
+    )
+    assert (
+        url_utils.classify_url("https://github.com/huggingface/transformers") == "code"
+    )
 
 
 def test_classify_url_invalid():
@@ -94,7 +93,7 @@ def test_classify_urls_too_many_urls():
         "https://huggingface.co/microsoft/DialoGPT-medium",
         "https://github.com/huggingface/transformers",
         "https://huggingface.co/datasets/squad",
-        "https://example.com/extra"
+        "https://example.com/extra",
     ]
     with pytest.raises(ValueError, match="No more than 3 URLs allowed"):
         url_utils.classify_urls(urls)


### PR DESCRIPTION
- Created requirements-linting.txt
- Expanded pyproject.toml to more strictly configure our linting tools
- Used Black code formatter to meet PEP 8 styling, Flake8 to verify
- Added type annotations across most code files, from all the issues Mypy noted
- GitHub and dataset links are checked to be not None in Model. If they are None, the respective fetcher is no longer told to fetch None